### PR TITLE
Fix definition of silence_warnings method

### DIFF
--- a/lib/gandi.rb
+++ b/lib/gandi.rb
@@ -11,7 +11,7 @@ require 'gandi/errors'
 module Gandi
   VERSION = '2.0.2'
   
-  def silence_warnings
+  def self.silence_warnings
     old_verbose, $VERBOSE = $VERBOSE, nil
     yield
   ensure


### PR DESCRIPTION
At the moment loading gandi.rb fails with "undefined method `silence_warnings' for Gandi:Module".
