### PR TITLE
Add 'xmlrpc' depedency: XML-RPC support was removed from ruby 2.4.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-.DS_Store
-*.gem
+/.bundle/
+/.yardoc
+/Gemfile
+/Gemfile.lock
+/coverage/
+/doc/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,83 @@
+AllCops:
+   TargetRubyVersion: 2.4
+
+Style/EmptyLinesAroundClassBody:
+   Description: Keeps track of empty lines around class bodies.
+   Enabled: true
+   EnforcedStyle: empty_lines
+   SupportedStyles:
+   - empty_lines
+   - no_empty_lines
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+  EnforcedStyle: when_needed
+  SupportedStyles:
+  - when_needed
+  - always
+
+Debugger:
+   Enabled: false
+Style/FormatString:
+   Description: Enforce the use of Kernel#sprintf, Kernel#format or String#%.
+   StyleGuide: https://github.com/bbatsov/ruby-style-guide#sprintf
+   Enabled: true
+   EnforcedStyle: percent
+
+
+Style/EmptyLinesAroundMethodBody:
+   Description: Keeps track of empty lines around method bodies.
+   Enabled: true
+
+Style/TrailingWhitespace:
+   Description: Avoid trailing whitespace.
+   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace
+   Enabled: false
+
+Style/IndentationWidth:
+   Description: Use 2 spaces for indentation.
+   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
+   Enabled: true
+   Width: 2
+
+Style/RegexpLiteral:
+   Description: Use / or %r around regular expressions.
+   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-r
+   Enabled: true
+   EnforcedStyle: slashes
+   AllowInnerSlashes: true
+
+Metrics/MethodLength:
+   Description: Avoid methods longer than 30 lines of code.
+   StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
+   Enabled: true
+   CountComments: false
+   Max: 30
+
+Metrics/AbcSize:
+   Description: A calculated magnitude based on number of assignments, branches, and conditions.
+   Reference: http://c2.com/cgi/wiki?AbcMetric
+   Enabled: true
+   Max: 30
+
+Style/SignalException:
+   Description: Checks for proper usage of fail and raise.
+   StyleGuide: https://github.com/bbatsov/ruby-style-guide#prefer-raise-over-fail
+   Enabled: true
+   EnforcedStyle: only_fail
+   SupportedStyles:
+   - only_raise
+   - only_fail
+   - semantic
+
+Metrics/LineLength:
+  Description: Limit lines to 80 characters.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
+  Enabled: true
+  Max: 200
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+  - http
+  - https
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: ruby
+rvm:
+  - 2.4.0
+before_install: gem install bundler -v 1.14.6

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at m@matthi.coffee. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/MatthiasWinkelmann/gandi.svg?branch=master)](https://travis-ci.org/MatthiasWinkelmann/gandi)
+
 # Gandi
 
 This is a Ruby interface to the [Gandi](http://gandi.net) XML-RPC API.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end

--- a/gandi.gemspec
+++ b/gandi.gemspec
@@ -1,21 +1,28 @@
-$LOAD_PATH << File.join(File.dirname(__FILE__), 'lib')
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'gandi/version'
 
-include_files = ['README*', 'Rakefile', 'init.rb', '{lib,tasks,test,rails,generators,shoulda_macros}/**/*'].map do |glob|
-   Dir[glob]
-end.flatten
-
-Gem::Specification.new do |s|
-  s.name              = 'gandi'
-  s.version           = '3.3.28'
-  s.license           = 'MIT'
-  s.date              = Time.now.strftime('%Y-%m-%d')
-  s.summary           = 'Gandi XML RPC API v3'
-  s.author            = 'Olivier Ruffin'
-  s.description       = 'Wrapper around gandi xml-rpc API v3'
-  s.homepage          = 'https://github.com/veilleperso/gandi'
-  s.has_rdoc          = false
-  s.files             = include_files
-  s.require_path      = 'lib'
-  s.add_dependency 'hashie'
-  s.add_dependency 'xmlrpc'
+Gem::Specification.new do |spec|
+  spec.name              = 'gandi'
+  spec.version           = Gandi::VERSION
+  spec.date              = Time.now.strftime('%Y-%m-%d')
+  spec.summary           = 'Gandi XML RPC API v3'
+  spec.author            = 'Olivier Ruffin'
+  spec.description       = 'Wrapper around gandi xml-rpc API v3'
+  spec.homepage          = 'https://github.com/veilleperso/gandi'
+  spec.has_rdoc          = false
+  spec.license           = 'MIT'
+  spec.files             = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(/^(test|spec|features)\//)
+  end
+  spec.require_paths = ['lib']
+  spec.metadata['yard.run'] = 'yri'
+  spec.add_dependency 'hashie'
+  spec.add_dependency 'xmlrpc'
+  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'simplecov', '~> 0.14'
 end

--- a/gandi.gemspec
+++ b/gandi.gemspec
@@ -1,20 +1,21 @@
 $LOAD_PATH << File.join(File.dirname(__FILE__), 'lib')
 
-include_files = ["README*", "Rakefile", "init.rb", "{lib,tasks,test,rails,generators,shoulda_macros}/**/*"].map do |glob|
-  Dir[glob]
+include_files = ['README*', 'Rakefile', 'init.rb', '{lib,tasks,test,rails,generators,shoulda_macros}/**/*'].map do |glob|
+   Dir[glob]
 end.flatten
 
 Gem::Specification.new do |s|
-  s.name              = "gandi"
-  s.version           = '3.3.27'
+  s.name              = 'gandi'
+  s.version           = '3.3.28'
   s.license           = 'MIT'
   s.date              = Time.now.strftime('%Y-%m-%d')
-  s.summary           = "Gandi XML RPC API v3"
-  s.author            = "Olivier Ruffin"
-  s.description       = "Wrapper around gandi xml-rpc API v3"
-  s.homepage          = "https://github.com/veilleperso/gandi"
+  s.summary           = 'Gandi XML RPC API v3'
+  s.author            = 'Olivier Ruffin'
+  s.description       = 'Wrapper around gandi xml-rpc API v3'
+  s.homepage          = 'https://github.com/veilleperso/gandi'
   s.has_rdoc          = false
   s.files             = include_files
-  s.require_path      = "lib"
+  s.require_path      = 'lib'
   s.add_dependency 'hashie'
+  s.add_dependency 'xmlrpc'
 end

--- a/lib/gandi.rb
+++ b/lib/gandi.rb
@@ -1,22 +1,20 @@
-# Add the directory containing this file to the start of the load path if it isn't there already.
-$:.unshift(File.dirname(__FILE__)) unless $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))
-
 require 'hashie'
 require 'xmlrpc/client'
+require 'gandi/version'
 require 'gandi/session'
 require 'gandi/errors'
 require 'gandi/fault_code'
 
 module Gandi
-  VERSION = '3.3.27'
-
+   
   ENDPOINT = {
     test: 'https://rpc.ote.gandi.net/xmlrpc/',
-    production: 'https://rpc.gandi.net/xmlrpc/',
-  }
+    production: 'https://rpc.gandi.net/xmlrpc/'
+  }.freeze
 
   def self.silence_warnings
-    old_verbose, $VERBOSE = $VERBOSE, nil
+    old_verbose = $VERBOSE
+    $VERBOSE = nil
     yield
   ensure
     $VERBOSE = old_verbose

--- a/lib/gandi/session.rb
+++ b/lib/gandi/session.rb
@@ -1,273 +1,295 @@
 module Gandi
-  OLD_METHODS = %w(
-  domain.owner.set_dry_run
-  hosting.iface.ip_attach
-  hosting.iface.ip_detach
-  hosting.ip.create
-  hosting.ip.delete
-  )
-  VALID_METHODS = %w(
-  catalog.list
-
-  cert.change_dcv
-  cert.count
-  cert.create
-  cert.delete
-  cert.get_dcv_params
-  cert.info
-  cert.list
-  cert.package.list
-  cert.renew
-  cert.resend_dcv
-  cert.update
-
-  contact.balance
-  contact.can_associate
-  contact.can_associate_domain
-  contact.count
-  contact.create
-  contact.delete
-  contact.info
-  contact.list
-  contact.release
-  contact.update
-  contact.reachability.resend
-
-  datacenter.list
-
-  domain.autorenew.activate
-  domain.autorenew.deactivate
-  domain.available
-  domain.contacts.set
-  domain.count
-  domain.create
-  domain.claims.accept
-  domain.claims.check
-  domain.claims.info
-  domain.delete.accept
-  domain.delete.available
-  domain.delete.decline
-  domain.delete.info
-  domain.delete.proceed
-  domain.dnssec.create
-  domain.dnssec.delete
-  domain.dnssec.list
-  domain.eoi.count
-  domain.eoi.create
-  domain.eoi.delete
-  domain.eoi.info
-  domain.eoi.list
-  domain.forward.count
-  domain.forward.create
-  domain.forward.delete
-  domain.forward.list
-  domain.forward.update
-  domain.host.count
-  domain.host.create
-  domain.host.delete
-  domain.host.info
-  domain.host.list
-  domain.host.update
-  domain.info
-  domain.list
-  domain.mailbox.alias.set
-  domain.mailbox.count
-  domain.mailbox.create
-  domain.mailbox.delete
-  domain.mailbox.info
-  domain.mailbox.list
-  domain.mailbox.purge
-  domain.mailbox.responder.activate
-  domain.mailbox.responder.deactivate
-  domain.mailbox.update
-  domain.misc.ukrights
-  domain.nameservers.set
-  domain.owner.set
-  domain.packmail.autorenew
-  domain.packmail.create
-  domain.packmail.delete
-  domain.packmail.info
-  domain.packmail.renew
-  domain.packmail.update
-  domain.release
-  domain.renew
-  domain.reseller.set
-  domain.restore
-  domain.smd.count
-  domain.smd.create
-  domain.smd.delete
-  domain.smd.extract
-  domain.smd.info
-  domain.smd.list
-  domain.status.lock
-  domain.status.unlock
-  domain.tld.list
-  domain.tld.region
-  domain.transferin.available
-  domain.transferin.proceed
-  domain.webredir.count
-  domain.webredir.create
-  domain.webredir.delete
-  domain.webredir.list
-  domain.webredir.update
-  domain.zone.clone
-  domain.zone.count
-  domain.zone.create
-  domain.zone.delete
-  domain.zone.info
-  domain.zone.list
-  domain.zone.record.add
-  domain.zone.record.count
-  domain.zone.record.delete
-  domain.zone.record.list
-  domain.zone.record.set
-  domain.zone.record.update
-  domain.zone.set
-  domain.zone.update
-  domain.zone.version.count
-  domain.zone.version.delete
-  domain.zone.version.list
-  domain.zone.version.new
-  domain.zone.version.set
-
-  hosting.catalog.list
-  hosting.catalog.price
-  hosting.datacenter.list
-  hosting.disk.count
-  hosting.disk.create
-  hosting.disk.create_from
-  hosting.disk.delete
-  hosting.disk.info
-  hosting.disk.list
-  hosting.disk.list_kernels
-  hosting.disk.list_options
-  hosting.disk.rollback_from
-  hosting.disk.update
-  hosting.iface.count
-  hosting.iface.create
-  hosting.iface.delete
-  hosting.iface.info
-  hosting.iface.list
-  hosting.iface.update
-  hosting.image.info
-  hosting.image.list
-  hosting.ip.count
-  hosting.ip.info
-  hosting.ip.list
-  hosting.ip.update
-  hosting.metric.available
-  hosting.metric.query
-  hosting.product.create
-  hosting.product.delete
-  hosting.product.renew
-  hosting.product.update
-  hosting.rating.list
-  hosting.rproxy.probe.check_server
-  hosting.rproxy.probe.disable
-  hosting.rproxy.probe.enable
-  hosting.rproxy.probe.test
-  hosting.rproxy.probe.update
-  hosting.rproxy.count
-  hosting.rproxy.create
-  hosting.rproxy.delete
-  hosting.rproxy.info
-  hosting.rproxy.list
-  hosting.rproxy.update
-  hosting.rproxy.server.count
-  hosting.rproxy.server.create
-  hosting.rproxy.server.delete
-  hosting.rproxy.server.disable
-  hosting.rproxy.server.enable
-  hosting.rproxy.server.list
-  hosting.rproxy.vhost.alter_zone
-  hosting.rproxy.vhost.count
-  hosting.rproxy.vhost.create
-  hosting.rproxy.vhost.delete
-  hosting.rproxy.vhost.get_dns_entries
-  hosting.rproxy.vhost.list
-  hosting.ssh.count
-  hosting.ssh.create
-  hosting.ssh.delete
-  hosting.ssh.info
-  hosting.ssh.list
-  hosting.vlan.count
-  hosting.vlan.create
-  hosting.vlan.delete
-  hosting.vlan.info
-  hosting.vlan.list
-  hosting.vlan.update
-  hosting.vm.count
-  hosting.vm.create
-  hosting.vm.create_from
-  hosting.vm.delete
-  hosting.vm.disk_attach
-  hosting.vm.disk_detach
-  hosting.vm.disk_rollback
-  hosting.vm.iface_attach
-  hosting.vm.iface_detach
-  hosting.vm.info
-  hosting.vm.list
-  hosting.vm.reboot
-  hosting.vm.start
-  hosting.vm.stop
-  hosting.vm.update
-
-  notification.count
-  notification.list
-  notification.test
-  notification.subscription.count
-  notification.subscription.create
-  notification.subscription.delete
-  notification.subscription.list
-
-  operation.cancel
-  operation.count
-  operation.info
-  operation.list
-  operation.relaunch
-
-  paas.count
-  paas.create
-  paas.delete
-  paas.info
-  paas.list
-  paas.renew
-  paas.restart
-  paas.snapshot.count
-  paas.snapshot.info
-  paas.snapshot.list
-  paas.type.count
-  paas.type.list
-  paas.update
-  paas.vhost.count
-  paas.vhost.create
-  paas.vhost.delete
-  paas.vhost.get_dns_entries
-  paas.vhost.info
-  paas.vhost.list
-
-  security.key.renew
-
-  site.alter_zone
-  site.count
-  site.create
-  site.delete
-  site.edit
-  site.get_dns_entries
-  site.info
-  site.key.create
-  site.key.delete
-  site.key.list
-  site.key.update
-  site.list
-  site.package.list
-  site.renew
-  site.update
-
-  version.info
-  )
-
+  VALID_METHODS = [
+  'account.credit',
+  'account.info',
+  'catalog.list',
+  'changeowner.create',
+  'contact.autofoa.count',
+  'contact.autofoa.create',
+  'contact.autofoa.delete',
+  'contact.autofoa.list',
+  'contact.autofoa.validate',
+  'contact.balance',
+  'contact.can_associate',
+  'contact.can_associate_domain',
+  'contact.count',
+  'contact.create',
+  'contact.delete',
+  'contact.info',
+  'contact.list',
+  'contact.reachability.resend',
+  'contact.release',
+  'contact.update',
+  'datacenter.list',
+  'disk.count',
+  'disk.create',
+  'disk.create_from',
+  'disk.delete',
+  'disk.info',
+  'disk.list',
+  'disk.list_kernels',
+  'disk.list_options',
+  'disk.rollback_from',
+  'disk.update',
+  'domain.autorenew.activate',
+  'domain.autorenew.deactivate',
+  'domain.available',
+  'domain.claims.accept',
+  'domain.claims.check',
+  'domain.claims.info',
+  'domain.contacts.set',
+  'domain.count',
+  'domain.create',
+  'domain.delete.accept',
+  'domain.delete.available',
+  'domain.delete.decline',
+  'domain.delete.info',
+  'domain.delete.proceed',
+  'domain.dnssec.create',
+  'domain.dnssec.delete',
+  'domain.dnssec.list',
+  'domain.eoi.count',
+  'domain.eoi.create',
+  'domain.eoi.delete',
+  'domain.eoi.info',
+  'domain.eoi.list',
+  'domain.forward.count',
+  'domain.forward.create',
+  'domain.forward.delete',
+  'domain.forward.list',
+  'domain.forward.update',
+  'domain.gandimail.activate',
+  'domain.gandimail.deactivate',
+  'domain.gandimail.info',
+  'domain.host.count',
+  'domain.host.create',
+  'domain.host.delete',
+  'domain.host.info',
+  'domain.host.list',
+  'domain.host.update',
+  'domain.info',
+  'domain.list',
+  'domain.mailbox.alias.set',
+  'domain.mailbox.count',
+  'domain.mailbox.create',
+  'domain.mailbox.delete',
+  'domain.mailbox.info',
+  'domain.mailbox.list',
+  'domain.mailbox.purge',
+  'domain.mailbox.responder.activate',
+  'domain.mailbox.responder.deactivate',
+  'domain.mailbox.update',
+  'domain.misc.ukrights',
+  'domain.nameservers.set',
+  'domain.owner.set',
+  'domain.packmail.autorenew',
+  'domain.packmail.create',
+  'domain.packmail.delete',
+  'domain.packmail.info',
+  'domain.packmail.renew',
+  'domain.packmail.update',
+  'domain.push',
+  'domain.release',
+  'domain.renew',
+  'domain.reseller.set',
+  'domain.restore',
+  'domain.smd.count',
+  'domain.smd.create',
+  'domain.smd.delete',
+  'domain.smd.extract',
+  'domain.smd.info',
+  'domain.smd.list',
+  'domain.status.lock',
+  'domain.status.unlock',
+  'domain.tld.list',
+  'domain.tld.region',
+  'domain.transferin.available',
+  'domain.transferin.proceed',
+  'domain.webredir.count',
+  'domain.webredir.create',
+  'domain.webredir.delete',
+  'domain.webredir.list',
+  'domain.webredir.update',
+  'domain.zone.clone',
+  'domain.zone.count',
+  'domain.zone.create',
+  'domain.zone.delete',
+  'domain.zone.info',
+  'domain.zone.list',
+  'domain.zone.record.add',
+  'domain.zone.record.count',
+  'domain.zone.record.delete',
+  'domain.zone.record.list',
+  'domain.zone.record.set',
+  'domain.zone.record.update',
+  'domain.zone.set',
+  'domain.zone.update',
+  'domain.zone.version.count',
+  'domain.zone.version.delete',
+  'domain.zone.version.list',
+  'domain.zone.version.new',
+  'domain.zone.version.set',
+  'hosting.account.credit',
+  'hosting.account.info',
+  'hosting.catalog.list',
+  'hosting.catalog.price',
+  'hosting.datacenter.list',
+  'hosting.disk.count',
+  'hosting.disk.create',
+  'hosting.disk.create_from',
+  'hosting.disk.delete',
+  'hosting.disk.info',
+  'hosting.disk.list',
+  'hosting.disk.list_kernels',
+  'hosting.disk.list_options',
+  'hosting.disk.rollback_from',
+  'hosting.disk.update',
+  'hosting.iface.count',
+  'hosting.iface.create',
+  'hosting.iface.delete',
+  'hosting.iface.info',
+  'hosting.iface.list',
+  'hosting.iface.update',
+  'hosting.image.info',
+  'hosting.image.list',
+  'hosting.ip.count',
+  'hosting.ip.info',
+  'hosting.ip.list',
+  'hosting.ip.update',
+  'hosting.metric.available',
+  'hosting.metric.query',
+  'hosting.package.count',
+  'hosting.package.list',
+  'hosting.product.create',
+  'hosting.product.delete',
+  'hosting.product.renew',
+  'hosting.product.update',
+  'hosting.rating.list',
+  'hosting.rproxy.count',
+  'hosting.rproxy.create',
+  'hosting.rproxy.delete',
+  'hosting.rproxy.info',
+  'hosting.rproxy.list',
+  'hosting.rproxy.probe.check_server',
+  'hosting.rproxy.probe.disable',
+  'hosting.rproxy.probe.enable',
+  'hosting.rproxy.probe.test',
+  'hosting.rproxy.probe.update',
+  'hosting.rproxy.server.count',
+  'hosting.rproxy.server.create',
+  'hosting.rproxy.server.delete',
+  'hosting.rproxy.server.disable',
+  'hosting.rproxy.server.enable',
+  'hosting.rproxy.server.list',
+  'hosting.rproxy.update',
+  'hosting.rproxy.vhost.alter_zone',
+  'hosting.rproxy.vhost.count',
+  'hosting.rproxy.vhost.create',
+  'hosting.rproxy.vhost.delete',
+  'hosting.rproxy.vhost.get_dns_entries',
+  'hosting.rproxy.vhost.info',
+  'hosting.rproxy.vhost.list',
+  'hosting.snapshotprofile.count',
+  'hosting.snapshotprofile.list',
+  'hosting.ssh.count',
+  'hosting.ssh.create',
+  'hosting.ssh.delete',
+  'hosting.ssh.info',
+  'hosting.ssh.list',
+  'hosting.vlan.count',
+  'hosting.vlan.create',
+  'hosting.vlan.delete',
+  'hosting.vlan.info',
+  'hosting.vlan.list',
+  'hosting.vlan.update',
+  'hosting.vm.count',
+  'hosting.vm.create',
+  'hosting.vm.create_from',
+  'hosting.vm.delete',
+  'hosting.vm.disk_attach',
+  'hosting.vm.disk_detach',
+  'hosting.vm.disk_rollback',
+  'hosting.vm.iface_attach',
+  'hosting.vm.iface_detach',
+  'hosting.vm.info',
+  'hosting.vm.list',
+  'hosting.vm.reboot',
+  'hosting.vm.start',
+  'hosting.vm.stop',
+  'hosting.vm.update',
+  'iface.count',
+  'iface.create',
+  'iface.delete',
+  'iface.info',
+  'iface.list',
+  'iface.update',
+  'image.info',
+  'image.list',
+  'ip.count',
+  'ip.info',
+  'ip.list',
+  'ip.update',
+  'notification.count',
+  'notification.list',
+  'notification.subscription.count',
+  'notification.subscription.create',
+  'notification.subscription.delete',
+  'notification.subscription.list',
+  'notification.test',
+  'operation.cancel',
+  'operation.count',
+  'operation.info',
+  'operation.list',
+  'operation.relaunch',
+  'paas.count',
+  'paas.create',
+  'paas.delete',
+  'paas.info',
+  'paas.list',
+  'paas.renew',
+  'paas.restart',
+  'paas.snapshot.count',
+  'paas.snapshot.info',
+  'paas.snapshot.list',
+  'paas.snapshotprofile.count',
+  'paas.snapshotprofile.list',
+  'paas.type.count',
+  'paas.type.list',
+  'paas.update',
+  'paas.vhost.count',
+  'paas.vhost.create',
+  'paas.vhost.delete',
+  'paas.vhost.get_dns_entries',
+  'paas.vhost.info',
+  'paas.vhost.list',
+  'product.create',
+  'product.delete',
+  'product.renew',
+  'product.update',
+  'snapshotprofile.count',
+  'snapshotprofile.list',
+  'system.listMethods',
+  'system.methodHelp',
+  'system.methodSignature',
+  'version.info',
+  'vm.count',
+  'vm.create',
+  'vm.create_from',
+  'vm.delete',
+  'vm.disk_attach',
+  'vm.disk_detach',
+  'vm.disk_rollback',
+  'vm.iface_attach',
+  'vm.iface_detach',
+  'vm.info',
+  'vm.list',
+  'vm.reboot',
+  'vm.start',
+  'vm.stop',
+  'vm.update'
+]
   class ProxyCall
+
     attr_accessor :server, :api_key, :chained
 
     def initialize(server, api_key)
@@ -280,38 +302,35 @@ module Gandi
     undef_method :clone
 
     def method_missing(method, *args)
-      self.chained << method
-      method_name = chained.join(".")
-      if Gandi::VALID_METHODS.include?(method_name)
-        begin
-          res = self.server.call(method_name, api_key, *args)
-        rescue XMLRPC::FaultException => e
-          raise Gandi::FaultCode.parse(e.faultCode, e.faultString).exception
-        end
+      chained << method
+      method_name = chained.join('.')
+      return self unless Gandi::VALID_METHODS.include?(method_name)
+      begin
+        res = server.call(method_name, api_key, *args)
+      rescue XMLRPC::FaultException => e
+        fail Gandi::FaultCode.parse(e.faultCode, e.faultString).exception
+      end
 
-        if res.is_a?(Array)
-          res.collect! { |x| x.is_a?(Hash) ? Hashie::Mash.new(x) : x }
-        elsif res.is_a?(Hash)
-          Hashie::Mash.new(res)
-        else
-          res
-        end
+      if res.is_a?(Array)
+        res.collect! { |x| x.is_a?(Hash) ? Hashie::Mash.new(x) : x }
+      elsif res.is_a?(Hash)
+        Hashie::Mash.new(res)
       else
-        self
+        res
       end
     end
+
   end
 
   class Session
+
     attr_reader :api_key
 
     def initialize(api_key, options = {})
       endpoint = options.is_a?(Hash) ? (ENDPOINT[options[:env]] || ENDPOINT[:production]) : options
 
-      @api_key  = api_key
+      @api_key = api_key
       @server = XMLRPC::Client.new2(endpoint)
-      # fix a bug in ruby 2.0, http://bugs.ruby-lang.org/issues/8182
-      @server.http_header_extra = { "accept-encoding" => "identity" }
       @server
     end
 
@@ -328,7 +347,8 @@ module Gandi
     end
 
     def method_missing(method, *args)
-      ProxyCall.new(@server, self.api_key).send(method, *args)
+      ProxyCall.new(@server, api_key).send(method, *args)
     end
+
   end
 end

--- a/lib/gandi/version.rb
+++ b/lib/gandi/version.rb
@@ -1,0 +1,3 @@
+module Gandi
+  VERSION = '3.2.78'.freeze
+end

--- a/test/contact_test.rb
+++ b/test/contact_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class ContactTest < Minitest::Test
+
+  def setup
+    @api = connect
+  end
+
+  def test_creating
+    contact = @api.contact.create(
+      type: 0,
+      given: 'Gottkanler',
+      family: 'Schulz',
+      streetaddr: 'Lausitzer Str. 25',
+      zip: '10999',
+      city: 'Berlin',
+      country: 'DE',
+      phone: '+49 151 23563201',
+      password: '********',
+      email: 'gottkanzler@test.com'
+    )
+
+    refute_nil contact
+  end
+
+end

--- a/test/domain_test.rb
+++ b/test/domain_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+class DomainTest < Minitest::Test
+
+  def setup
+    @api = connect
+    random = (0..10).map { rand(10) }.join
+    @domain = @api.domain.create(
+      "my-test-#{random}.tv",
+      owner: @api.account.info['handle'],
+      admin: @api.account.info['handle'],
+      tech: @api.account.info['handle'],
+      bill: @api.account.info['handle'],
+      duration: 1
+    )
+  end
+
+  def test_creating
+    refute_nil @domain
+  end
+
+end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+require 'pry'
+class SessionTest < Minitest::Test
+
+  def setup
+    @api = connect
+  end
+
+  def test_connecting
+    refute_nil @api
+  end
+
+  def test_methods
+    assert_equal @api.list_methods, Gandi::VALID_METHODS
+  end
+
+  def test_account
+    refute_nil @api.account.info['handle']
+  end
+
+  def test_remote_hostname
+    assert_equal @api.server.instance_variable_get('@host'), 'rpc.ote.gandi.net'
+  end
+
+  def test_encryption
+    assert @api.server.instance_variable_get '@use_ssl'
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,21 @@
+require 'simplecov'
+SimpleCov.start
+
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
+require 'gandi'
+
+unless ENV['GANDI_API_TEST_KEY']
+  fail '
+
+    Could not find environment variable $GANDI_API_TEST_KEY
+    Please set it to the OT&E Key provided by Gandi. You can find
+    it at https://www.gandi.net/admin/api_key.
+    '
+end
+
+def connect
+  Gandi::Session.new(ENV['GANDI_API_TEST_KEY'], env: :test)
+end
+
+require 'minitest/autorun'


### PR DESCRIPTION
Add 'xmlrpc' depedency: XML-RPC support was rmoved from the ruby stdlib in 2.4.0 (https://bugs.ruby-lang.org/issues/12160) and now requires the external gem.

This also standardises the quotes and bumps the patch version.

